### PR TITLE
Use int for teammate ID, not string

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -33,7 +33,7 @@ type Customer struct {
 
 type Teammate struct {
 	Type string `json:"type"`
-	ID   string `json:"id"`
+	ID   int64  `json:"id"`
 }
 
 // A ConversationRating is the customer satisfaction rating result

--- a/fixtures/conversation.json
+++ b/fixtures/conversation.json
@@ -68,7 +68,7 @@
     },
     "teammate": {
       "type": "admin",
-      "id": "25"
+      "id": 25
     }
   }
 }


### PR DESCRIPTION
Intercom's docs are wrong